### PR TITLE
Add support for MCP4725

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Go packages for pheripheral I/O. It contains driver for the following IC's:
         * MAX5813
         * MAX5814
         * MAX5815
+    * [Microchip][i2c/microchip]
+        * MCP4725
 
 ## License
 
@@ -22,4 +24,5 @@ System][acs].
 [acs]: http://advancedclimate.nl
 [mpl]: LICENSE
 [i2c/max]: https://godoc.org/github.com/AdvancedClimateSystems/io/i2c/max
+[i2c/microchip]: https://godoc.org/github.com/AdvancedClimateSystems/io/i2c/microchip
 [spi/microchip]: https://godoc.org/github.com/AdvancedClimateSystems/io/spi/microchip

--- a/i2c/max/README.md
+++ b/i2c/max/README.md
@@ -35,7 +35,7 @@ func main() {
 	defer d.Close()
 
 
-	// 2.5 is the input reference of the DAC.
+	// 2.5V is the input reference of the DAC.
 	dac, err := max.NewMAX5813(d, 2.5)
 
 	if err != nil {

--- a/i2c/microchip/README.md
+++ b/i2c/microchip/README.md
@@ -1,0 +1,54 @@
+[![godoc](https://img.shields.io/badge/godoc-reference-blue.svg?style=flat)](https://godoc.org/github.com/AdvancedClimateSystems/io/i2c/microchip)
+
+# Microchip
+
+Package microchip implements drivers for I<sup>2</sup>C controlled IC's
+produced by [Microchip](http://www.microchip.com).
+
+Drivers for the following IC's are implemented:
+
+* [MCP4725](http://www.microchip.com/wwwproducts/DevicePrint/en/MCP4725?httproute=True)
+
+Sample usage:
+
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/advancedclimatesystems/io/i2c/microchip"
+	"golang.org/x/exp/io/i2c"
+)
+
+func main() {
+	d, err := i2c.Open(&i2c.Devfs{
+		Dev: "/dev/i2c-0",
+	}, 0x61)
+
+	if err != nil {
+		panic(fmt.Sprintf("failed to open device: %v", err))
+	}
+	defer d.Close()
+
+	// Reference voltage is 2.7V.
+	dac, err := microchip.NewMCP4725(d, 2.7)
+
+	if err != nil {
+		panic(fmt.Sprintf("failed to create MCP4725: %v", err))
+	}
+
+	// Set output of channel 1 to 1.3V. The MCP4725 has only 1 channel,
+	// select other channels results in an error.
+	if err := dac.SetVoltage(3, 1); err != nil {
+		panic(fmt.Sprintf("failed to set voltage: %v", err))
+	}
+
+	// It's also possible to set output of a channel with digital output
+	// code. The value must be in range of 0 till 4096.
+	if err := dac.SetInputCode(4095, 1); err != nil {
+		panic(fmt.Sprintf("failed to set voltage using output code: %v", err))
+	}
+}
+```

--- a/i2c/microchip/mcp4725.go
+++ b/i2c/microchip/mcp4725.go
@@ -1,0 +1,70 @@
+// Package microchip implements drivers for a few I2C controlled chips produced
+// by Microchip.
+package microchip
+
+import (
+	"fmt"
+
+	"golang.org/x/exp/io/i2c"
+)
+
+// The MCP4725 has a 14 bit wide EEPROM to store configuration bits (2 bits)
+// and DAC input data (12 bits)
+//
+// The MCP4275 also has a 19 bits DAC register. The master can read/write the
+// DAC register or EEPROM using i2c interface.
+//
+// The MCP4725 device address contains four fixed bits (1100 = device code) and
+// three address bits (A2, A1, A0). The A2 and A1 bits are hard-wired during
+// manufactoring, and the A0 bit is determined by the logic state of AO pin.
+//
+// The MCP4725 has 2 modes of operation: normal mode and power-down mode. This
+// driver only supports normal mode.
+//
+// The datasheet of the device is here:
+// http://ww1.microchip.com/downloads/en/DeviceDoc/22039d.pdf
+type MCP4725 struct {
+	conn *i2c.Device
+	vref float64
+
+	Address int
+}
+
+// NewMCP4725 returns a new instance of MCP4725.
+func NewMCP4725(conn *i2c.Device, vref float64) (*MCP4725, error) {
+	return &MCP4725{
+		conn: conn,
+		vref: vref,
+	}, nil
+}
+
+// SetVoltage sets voltage of the only channel of the MCP4725. The channel
+// parameter is required in the signature of the function to be conform with
+// the dac.DAC interface. Because the MCP4725 has only 1 channel it's only
+// allowed value is 1.
+func (m MCP4725) SetVoltage(v float64, channel int) error {
+	code := v * 4096 / m.vref
+	return m.SetInputCode(int(code), channel)
+}
+
+// SetInputCode sets voltage of the only channel of the MCP4725. The channel
+// parameter is required in the signature of the function to be conform with
+// the dac.DAC interface. Because the MCP4725 has only 1 channel it's only
+// allowed value is 1.
+func (m MCP4725) SetInputCode(code, channel int) error {
+	if channel != 1 {
+		return fmt.Errorf("channel %d is invalid, MCP4725 has only 1 channel", channel)
+	}
+
+	if code < 0 || code >= 4096 {
+		return fmt.Errorf("digital input code %d is out of range of 0 <= code < 4096", code)
+	}
+
+	out := []byte{byte(code >> byte(8)), byte(code & 0xFF)}
+
+	if err := m.conn.Write(out); err != nil {
+		return fmt.Errorf("failed to write output code %d: %v", code, err)
+	}
+
+	return nil
+}

--- a/i2c/microchip/mcp4725_test.go
+++ b/i2c/microchip/mcp4725_test.go
@@ -1,0 +1,112 @@
+package microchip
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/advancedclimatesystems/io/dac"
+	"github.com/advancedclimatesystems/io/iotest"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/exp/io/i2c"
+)
+
+func TestDACinterface(t *testing.T) {
+	assert.Implements(t, (*dac.DAC)(nil), new(MCP4725))
+}
+
+func TestMCP4725WithValidVoltages(t *testing.T) {
+	data := make(chan []byte, 2)
+	c := iotest.NewI2CConn()
+
+	c.TxFunc(func(w, _ []byte) error {
+		data <- w
+		return nil
+	})
+
+	conn, _ := i2c.Open(iotest.NewI2CDriver(c), 0x1)
+
+	var tests = []struct {
+		vref     float64
+		voltage  float64
+		expected []byte
+	}{
+		{2.7, 1.73, []byte{0xa, 0x40}},
+		{2.7, 2.6999, []byte{0x0f, 0xff}},
+		{2.7, 0, []byte{0x0, 0x0}},
+		{5.5, 1.22, []byte{0x3, 0x8c}},
+		{5.5, 0.73, []byte{0x2, 0x1f}},
+	}
+
+	for _, test := range tests {
+		m, err := NewMCP4725(conn, test.vref)
+		assert.Nil(t, err)
+
+		err = m.SetVoltage(test.voltage, 1)
+		assert.Equal(t, test.expected, <-data)
+		assert.Nil(t, err)
+	}
+}
+
+func TestMCP4725WithInValidVoltages(t *testing.T) {
+	conn, _ := i2c.Open(iotest.NewI2CDriver(iotest.NewI2CConn()), 0x1)
+	m, _ := NewMCP4725(conn, 2.7)
+
+	voltages := []float64{-1, 28.1}
+	for _, v := range voltages {
+		err := m.SetVoltage(v, 1)
+		assert.NotNil(t, err)
+	}
+}
+
+func TestMCP4725WithInvalidChannel(t *testing.T) {
+	conn, _ := i2c.Open(iotest.NewI2CDriver(iotest.NewI2CConn()), 0x1)
+	m, _ := NewMCP4725(conn, 2.7)
+
+	channels := []int{-1, 0, 2, 28}
+	for _, c := range channels {
+		err := m.SetVoltage(1, c)
+		assert.NotNil(t, err)
+	}
+}
+
+func TestMCP4725WithFailingConnection(t *testing.T) {
+	c := iotest.NewI2CConn()
+	c.TxFunc(func(_, _ []byte) error { return errors.New("Is there a officer, problem?") })
+	conn, _ := i2c.Open(iotest.NewI2CDriver(c), 0x1)
+
+	m, _ := NewMCP4725(conn, 2.7)
+	err := m.SetVoltage(1, 1)
+
+	assert.NotNil(t, err)
+}
+
+func ExampleMCP4725() {
+	d, err := i2c.Open(&i2c.Devfs{
+		Dev: "/dev/i2c-0",
+	}, 0x61)
+
+	if err != nil {
+		panic(fmt.Sprintf("failed to open device: %v", err))
+	}
+	defer d.Close()
+
+	// Reference voltage is 2.7V.
+	dac, err := NewMCP4725(d, 2.7)
+
+	if err != nil {
+		panic(fmt.Sprintf("failed to create MCP4725: %v", err))
+	}
+
+	// Set output of channel 1 to 1.3V. The MCP4725 has only 1 channel,
+	// select other channels results in an error.
+	if err := dac.SetVoltage(3, 1); err != nil {
+		panic(fmt.Sprintf("failed to set voltage: %v", err))
+	}
+
+	// It's also possible to set output of a channel with digital output
+	// code. The value must be in range of 0 till 4096.
+	if err := dac.SetInputCode(4095, 1); err != nil {
+		panic(fmt.Sprintf("failed to set voltage using output code: %v", err))
+	}
+}

--- a/iotest/spi.go
+++ b/iotest/spi.go
@@ -1,0 +1,82 @@
+// Package iotest contains some test helpers for code relying on
+// golang.org/x/exp/io/i2c.
+//
+//  func TestMCP4725(t *testing.T)  {
+//	data := make(chan []byte, 2)
+//	c := iotest.NewI2CConn()
+//
+//	// Set the TxFunc.
+//	c.TxFunc(func(w, _ []byte) error {
+//		data <- w
+//		return nil
+//	})
+//
+//	conn, _ := i2c.Open(iotest.NewI2CDriver(c), 0x1)
+//	dac, _  := microchip.NewMCP4725(conn, 5.5)
+//
+//         // Under the hood SetInputCode calls c.Tx which in turn calls TxFunc defined earlier.
+//	dac.SetInputCode(0x539, 1)
+//
+//	assert.Equal(t, []byte{0x5, 0x39}, <-data)
+// }
+package iotest
+
+import (
+	"golang.org/x/exp/io/i2c/driver"
+)
+
+// I2CDriver implements the i2c.Device interface.
+type I2CDriver struct {
+	conn I2CConn
+}
+
+// NewI2CDriver creates a new I2CDriver.
+func NewI2CDriver(c I2CConn) *I2CDriver {
+	return &I2CDriver{conn: c}
+}
+
+// Open returns a type that implements the driver.Conn interface.
+func (d I2CDriver) Open(_ int, _ bool) (driver.Conn, error) {
+	return d.conn, nil
+}
+
+// I2CConn implements the driver.Conn interface.
+type I2CConn struct {
+	tx    func(w, r []byte) error
+	close func() error
+}
+
+// NewI2CConn creates a new I2CConn.
+func NewI2CConn() I2CConn {
+	c := I2CConn{}
+
+	c.TxFunc(func(_, _ []byte) error {
+		return nil
+	})
+
+	c.CloseFunc(func() error {
+		return nil
+	})
+
+	return c
+}
+
+// Tx calls the TxFunc.
+func (c I2CConn) Tx(w, r []byte) error {
+	return c.tx(w, r)
+}
+
+// TxFunc sets TxFunc which is called when Tx is called.
+func (c *I2CConn) TxFunc(f func(w, r []byte) error) {
+	c.tx = f
+}
+
+// Close calls the CloseFunc.
+func (c I2CConn) Close() error {
+	return c.close()
+}
+
+// CloseFunc sets the CloseFunc. CloseFunc is called when Close is called.
+func (c *I2CConn) CloseFunc(f func() error) {
+	c.close = f
+}

--- a/spi/microchip/mcp3x0x.go
+++ b/spi/microchip/mcp3x0x.go
@@ -1,6 +1,5 @@
 // Package microchip implements drivers for a few SPI controlled chips produced
-// by Microchip This package relies on
-// https://godoc.org/golang.org/x/exp/io/spi.
+// by Microchip.
 package microchip
 
 import (


### PR DESCRIPTION
The MCP4725 is a DAC build by Microchip. This commit also adds the
package iotest. This package contains test helpers for code using
golang.org/x/exp/io/i2c/.

Issues: #1