### PR TITLE
Fix channel validation MCP3004 and MCP3204

### DIFF
--- a/spi/microchip/mcp3x0x.go
+++ b/spi/microchip/mcp3x0x.go
@@ -22,7 +22,7 @@ type MCP3004 struct {
 
 // OutputCode queries the channel and returns its digital output code.
 func (m MCP3004) OutputCode(channel int) (int, error) {
-	if channel < 0 || channel > 4 {
+	if channel < 0 || channel > 3 {
 		return 0, fmt.Errorf("channel %d is invalid, ADC has only 4 channels", channel)
 	}
 
@@ -150,7 +150,7 @@ type MCP3204 struct {
 
 // OutputCode queries the channel and returns its digital output code.
 func (m MCP3204) OutputCode(channel int) (int, error) {
-	if channel < 0 || channel > 4 {
+	if channel < 0 || channel > 3 {
 		return 0, fmt.Errorf("channel %d is invalid, ADC has only 4 channels", channel)
 	}
 


### PR DESCRIPTION
The validation didn't fail when OutputCode(channel int) was called
with 4, which is an invalid channel number for these IC's.

This commit also brings test coverage for the microchip package to
100%.

Issues: #19