### PR TITLE
Fixed issue where SetEdge would stop working.

### DIFF
--- a/gpio/gpio.go
+++ b/gpio/gpio.go
@@ -215,6 +215,7 @@ func (p *Pin) SetEdge(e Edge, f EdgeEvent) error {
 	callback := func() {
 		f(p)
 	}
+	p.w.AddFile(valF)
 	if err = p.w.AddEvent(int(valF.Fd()), callback); err != nil {
 		return err
 	}


### PR DESCRIPTION
This was probably caused by a file desciptor becoming bad, after the file itself got garbage collected.
An AddFile function has been added to the watcher so that the watcher can keep a reference to the file.