### PR TITLE
Fixed default values for i2c in mcp4725 example

### DIFF
--- a/i2c/microchip/README.md
+++ b/i2c/microchip/README.md
@@ -24,8 +24,8 @@ import (
 
 func main() {
 	d, err := i2c.Open(&i2c.Devfs{
-		Dev: "/dev/i2c-0",
-	}, 0x61)
+		Dev: "/dev/i2c-1",
+	}, 0x60)
 
 	if err != nil {
 		panic(fmt.Sprintf("failed to open device: %v", err))


### PR DESCRIPTION
The i2c address for a standard mcp4725 is 0x60 and the ic2 on anything but I think the first raspberry pi's mounts on `/dev/i2c-1`. Since I presume many people (like me) will run this on a raspi with default values I think this is a more sane example which gets more people up and running quickly.